### PR TITLE
fix bug where mobile navbar would move as you scroll down the website

### DIFF
--- a/src/Components/NavBar/MenuIcon.css
+++ b/src/Components/NavBar/MenuIcon.css
@@ -2,7 +2,7 @@
   display: none;
 }
 
-@media (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .menuIcon__icon {
     transition: all 250ms cubic-bezier(0.25, 0.46, 0.45, 0.94) 0s;
     cursor: pointer;

--- a/src/Components/NavBar/Nav.css
+++ b/src/Components/NavBar/Nav.css
@@ -5,7 +5,7 @@
   align-items: center;
   justify-items: center;
 }
-@media (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .Nav {
     transition: all 1s ease-out;
     clip-path: circle(0px at 90% -10%);
@@ -28,5 +28,6 @@
   .active {
     clip-path: circle(1300px at 90% -10%);
     -webkit-clip-path: circle(1300px at 90% -10%);
+    top: 0;
   }
 }

--- a/src/Components/NavBar/NavItem.css
+++ b/src/Components/NavBar/NavItem.css
@@ -10,7 +10,7 @@
   transform: scale(1.1);
 }
 
-@media (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .navItem {
     margin: 20px;
     font-size: 30px;

--- a/src/Components/NavBar/ResumeButton.css
+++ b/src/Components/NavBar/ResumeButton.css
@@ -9,7 +9,7 @@
   color: white;
 }
 
-@media (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .resumeButton {
     margin: 20px;
   }


### PR DESCRIPTION
The navbar was broken when active and in mobile mode, as you scrolled down the website, the navbar would move around and not stay in place

Fixed this bug by adding `top: 0` to the navbar when it is active